### PR TITLE
Add External ressources section

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -22,6 +22,7 @@ To achieve these goals, the project is divided into the following sections:
 * [Pharo projects](https://github.com/pharo-open-documentation/pharo-wiki#pharo-projects) - documentation about subprojects contained in the Pharo general distribution.
 * [External projects](https://github.com/pharo-open-documentation/pharo-wiki#external-projects) - information about external projects. Most of the pages give some examples to give an idea on how those project work and offer comparisons between multiple projects around the same theme.
 * [Migration guidelines](https://github.com/pharo-open-documentation/pharo-wiki#migration-guidelines) - migration guides between different versions of Pharo.
+* [External ressources](https://github.com/pharo-open-documentation/pharo-wiki#external-ressources) - links to ressources not maintained by the wiki community but interesting to check-out.
 
 As long as they fit the goals of the wiki, the entries of this project can be:
 - documentation

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The goals of the wiki are explained in the [Manifest](MANIFEST.md) and contribut
 - [External projects](#external-projects)
   * [Data exchange](#data-exchange)
 - [Migration guidelines](#migration-guidelines)
+- [External ressources](#external-ressources)
 
 ## Beginners
 
@@ -64,6 +65,8 @@ The goals of the wiki are explained in the [Manifest](MANIFEST.md) and contribut
 ## Migration guidelines
 - [Migration from Pharo 6.1 to Pharo 7.0](Migration/MigrationToPharo7.md)
 
+## External ressources
+- [Contributing to Pharo](https://github.com/pharo-project/pharo/wiki/Contribute-a-fix-to-Pharo) (External link) - Official tutorial on how to contribute to Pharo using Iceberg.
 
 <!---
 Badges:


### PR DESCRIPTION
This section aims to hold links to ressources that are not managed by Pharo open documentation but are useful still.