### PR TITLE
Small fixes on rich text page

### DIFF
--- a/PharoProjects/RichText.md
+++ b/PharoProjects/RichText.md
@@ -2,17 +2,11 @@
 
 `Text` object models rich text. That is to say text that can be stylised with **bold**, *italics*, colors, different fonts and a few other things. The class `Text` is one of the really ancient classes in smalltalk.
 
-Here is short example showing how it works basically:
-
-```Smalltalk
-text := 'Hello World!' asText.
-text
-	addAttribute: TextEmphasis bold from: 1 to: 5;
-	addAttribute: (TextColor color: Color red) from: 7 to: 11;
-	addAttribute: (TextColor color: Color green) from: 12 to: 12.
-```
-
-If you inspect `text`, you will see that `Hello` is bold, `World` is red, `!` is green.
+- [TextEmphasis](#textemphasis)
+- [Colors](#colors)
+- [Different fonts](#different-fonts)
+- [Clickable text](#clickable-text)
+- [Inline images](#inline-images)
 
 ## TextEmphasis
 The class `TextEmphasis` defines a set of simple (no font change) changes you can do. See the class side of `TextEmphasis` for the supported styles of emphasis.
@@ -27,7 +21,14 @@ text
 ```
 
 ## Colors
-Colored text is done as shown above. Examine the class `Color` for other colors.
+Colored text is done as shown below. Examine the class `Color` for other colors.
+
+```Smalltalk
+text := 'Hello World!' asText.
+text
+	addAttribute: (TextColor color: Color red) from: 7 to: 11;
+	addAttribute: (TextColor color: Color green) from: 12 to: 12.
+```
 
 ## Different fonts
 Loading and managing fonts is an issue in itself.
@@ -49,7 +50,7 @@ largeAttribute := TextFontReference
 
 This should give you 'My larger text' with 'larger' being in font size 20 and in the 'Bitmap Source Sans Pro' font.
 
-## Clickable text.
+## Clickable text
 It is possible to make text do stuff when clicked. This is obviously a huge area. One simple example is:
 
 ```Smalltalk
@@ -75,10 +76,7 @@ anchoredImage,
 
 There are further examples in the class comment of `TextAnchor`.
 
-#### Notice.
-The inline images relies on the morphic system. Not all morphs seem to be able to be inlined in text in Pharo.
-
-In addition, you will most likely get the best results if you put images larger than the font size on a line by themself. The class comment of `TextAnchor` has an example of inlining a small icon.
-
-'My action text' asText addAttribute: textAction from: 4 to: 10.
-```
+> Note:
+> The inline images relies on the morphic system. Not all morphs seem to be able to be inlined in text in Pharo.
+> 
+> In addition, you will most likely get the best results if you put images larger than the font size on a line by themself. The class comment of `TextAnchor` has an example of inlining a small icon.

--- a/PharoProjects/RichText.md
+++ b/PharoProjects/RichText.md
@@ -2,11 +2,24 @@
 
 `Text` object models rich text. That is to say text that can be stylised with **bold**, *italics*, colors, different fonts and a few other things. The class `Text` is one of the really ancient classes in smalltalk.
 
+- [Quickstart](#quickstart)
 - [TextEmphasis](#textemphasis)
 - [Colors](#colors)
 - [Different fonts](#different-fonts)
 - [Clickable text](#clickable-text)
 - [Inline images](#inline-images)
+
+## Quickstart
+Here is a quick example illustrating how attributes can be added to `Text` object to create rich text in Pharo:
+
+```Smalltalk
+text := 'Hello World!' asText.
+text
+	addAttribute: TextEmphasis italic from: 7 to: 11;
+	addAttribute: TextEmphasis struckOut from: 7 to: 11;
+	addAttribute: (TextColor color: Color red) from: 7 to: 11;
+	addAttribute: (TextColor color: Color green) from: 12 to: 12.
+```
 
 ## TextEmphasis
 The class `TextEmphasis` defines a set of simple (no font change) changes you can do. See the class side of `TextEmphasis` for the supported styles of emphasis.


### PR DESCRIPTION
- Removed duplicated code from conflict resolution
- Changed Notice section to Note: with note style (as on other pages)
- Removed dot from section name
- Moved explanation at beginning to color section
- Added toc as the page gets bigger