### PR TITLE
Minor spelling and grammar correction for beginner section

### DIFF
--- a/General/Glossary.md
+++ b/General/Glossary.md
@@ -15,22 +15,22 @@ According to [wikipedia](https://en.wikipedia.org/wiki/Bootstrapping),
 > "Bootstrapping usually refers to a self-starting process that is supposed to proceed without external input."
 
 In the case of Pharo, [images](#image) are bootstrapped from the sources. Anyone can download the sources and [create their own custom Pharo image](https://github.com/carolahp/pharo/tree/candle). The Pharo [continuous integration server](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/) launch the bootstrap process each time a pull-request is merged into [pharo repository](https://github.com/pharo-project/pharo).
-This seems to be a natural process but one has to know that until Pharo 7.0, images were not bootstrapped. This means that, each version of Pharo was in fact a copy of the previous image with some additional changes.
+This seems to be a natural process but one has to know that up to Pharo 7.0, images were not bootstrapped. This means that, each version of Pharo was in fact a copy of the previous image with some additional changes.
 
 ## Browser
-The browser designate the tool for browsing and editing packages, classes and methods. In Pharo 6.1 and greater, the browser is Calypso.
+The browser is the tool for browsing and editing packages, classes and methods. In Pharo 6.1 and greater, the browser is called Calypso.
 
 ## Candidates
 In the context of a method-call the candidates are the potential classes in the system that can receive the call. This list is computed from a static analysis of the source code.
 
 ## Changes (file)
-The changesfile logs all source code modifications (especially all thechanges you did while programming) since the [sources file](#sources) was generated. This facilitates a per method history for diffs or reverting. It means that even if you did not manage to save the image file on a crash or you just forgot, you can recover your changes from this file. A changes file is always coupled with a image file. They work in pair.
+The changesfile logs all source code modifications (especially all the changes you did while programming) since the [sources file](#sources) was generated. This facilitates a per-method history for diffs or reverting. It means that even if you did not manage to save the image file on a crash or you just forgot to, you can recover your changes from this file. A changes file is always coupled with an image file. They work as a pair.
 
 > Note: Since Pharo 5, a project called Epicea implementing a new logging system has been introduced in the system. The long term goal of Epicea is to replace the changes file, but this objective has not been reached yet.
 
 ## Class-side
-The class-side of a class refers to its meta-class. This meta-class contain methods that can be send to the class directly.
-For example, `#x:y:` method (which create an instance of `Point` with arbitrary x and y coordinates) is held by the meta-class of `Point`.
+The class-side of a class refers to its meta-class. This meta-class contains methods that can be sent to the class directly.
+For example, `#x:y:` method (which creates an instance of `Point` with arbitrary x and y coordinates) is held by the meta-class of `Point`.
 
 In Pharo, both `Class` and `Metaclass` understand `#classSide` method.
 For example:
@@ -42,7 +42,7 @@ Point includesSelector: #x:y:. "false"
 Point class includesSelector: #x:y:. "true"
 ```
 
-The best way to understand what is the class-side is to have a look at `#classSide` methods implementations:
+The best way to understand what the class-side is, is to have a look at `#classSide` methods implementations:
 
 ```Smalltalk
 Class>>#classSide
@@ -59,39 +59,39 @@ Cog is the name of the [virtual machine](#virtual-machine) used by Pharo.
 It is also used by other programming languages such as [Squeak](#squeak), Newspeak and Cuis.
 
 ## Context
-A *Context* represent a program execution. It will store for example the `CompiledMethod` being currently executed, the receiver and arguments of the message that invoked this `CompiledMethod`, the temporary variables, the stack of calls until this moment of the execution, ...
-In Pharo, you can use the keyword `thisContext` to interact with the current context of your code. It will return the `Context` object at the moment of the execution. This object is different at each method call.
+A *Context* represent a program execution. It will store, for example, the `CompiledMethod` being currently executed, the receiver and arguments of the message that invoked this `CompiledMethod`, the temporary variables, the stack of calls until the moment of the execution, ...
+In Pharo, you can use the keyword `thisContext` to interact with the current context of your code. It will return the `Context` object at the moment of the execution. This object is different on each method call.
 
 ## Debugger
-The *Debugger* is a tool opened by the system when an exception is raised and never get caught. This tool allows the developer to interact with the execution [context](#context) that raised the error and its previous contexts. It let the users inspect the objects present in this context and update the code to fix the bug using the execution informations as a help.
+The *Debugger* is a tool opened by the system when an exception is raised and never got caught. This tool allows the developer to interact with the execution [context](#context) that raised the error and its previous contexts. It lets the users inspect the objects present in this context and updates the code to fix the bug using the execution information as help.
 
 ## Dispatch
-Dispatch is a technique used in object-oriented programming to delegate behavior using [polymorphism](#polymorphism). The goal is to define a concept that will changed depending on the context. For example we can have an application with commands. When we need to execute the command, instead of creating a switch/case, each object will implement its own behaviour on a method of the same name and we just need to call this method. 
+Dispatch is a technique used in object-oriented programming to delegate behavior using [polymorphism](#polymorphism). The goal is to define a concept that will change depending on the context. For example we can have an application with commands. When we need to execute the commands, instead of creating a switch/case, each object will implement its own behaviour on a method of the same name and we just need to call this method. 
 
 ## DNU
 See [DoesNotUnderstand](#doesnotunderstand).
 
 ## DoesNotUnderstand
-This name is used to designate the error that arises when a [message](#message) is sent to an object but this object does not understand it. It also happens that people use the "DNU" shortcut.
+This name is used to describe the error that arises when a [message](#message) is sent to an object but the object does not understand it. It also happens that people use the "DNU" shortcut.
 
 ## Iceberg
 *Iceberg* is git client integrated in the system since Pharo 7 (Pharo 6.1 contained a technical preview of the tool). It is a set of tools that allows one to handle git repositories directly from a Pharo image. Iceberg is the default repository manager for Pharo, allowing for smoother and faster integration of contributions, as well as better branch and version management.
 
 ## Image
-A Pharo image is a snapshot of Pharo memory at a given moment.
-This is the file where all objects are stored and as such it’s a cross platform format.
-An image file contains the live state of all objects of the system (including classes and compiled methods, since they are objects too) at a givenpoint.
+A Pharo image is a snapshot of Pharo memory at any given moment.
+This is the file where all objects are stored and as such, it’s a cross platform format.
+An image file contains the live state of all objects of the system (including classes and compiled methods, since they are objects too) at a given point.
 It can bee seen as a virtual object container.
 
 ## Implementors
 For a given selector in the system, implementors are classes that have a method with this selector (they implement the selector). For example the implementors of the method `#banana` are all the classes containing a method named `#banana`.
 
 ## Inspector
-The *Inspector* is a Pharo tool which allows one to inspect objects, see their current state, interact with them and display specific informations depending on the object. It offers multiple views and it uses a finder as a navigation. One particular feature is that you can use the evaluator tab to enter code, and evaluating it results in opening another pane to the right.
+The *Inspector* is a Pharo tool which allows one to inspect objects, see their current state, interact with them and display specific information depending on the object. It offers multiple views and it uses a Finder as a navigation. One particular feature is that you can use the evaluator tab to enter code, and evaluating it results in the opening of another pane to the right.
 
 ## Instance
 An instance is a concrete realisation of a class.
-One can send [messages](#message) to instance.
+One can send [messages](#message) to an instance.
 These messages correspond to methods defined by the class related to the instance.
 All instances of a class share the behaviour (methods) and structure ([slots](#slot)) defined by the class but two instances can hold different data in their [slots](#slot).
 
@@ -109,7 +109,7 @@ Point includesSelector: #x. "true"
 Point class includesSelector: #x. "false"
 ```
 
-The best way to understand what is the instance-side is to have a look at `#instanceSide` methods implementations:
+The best way to understand what the instance-side is, is to have a look at `#instanceSide` methods implementations:
 
 ```Smalltalk
 Class>>#instanceSide
@@ -125,25 +125,25 @@ Metaclass>>#instanceSide
 See [slot](#slot).
 
 ## Keyword message
-A keyword message is a [message](#message) where two or more objects are involved (the [receiver](#receiver) and the arguments). A message is composed of alphanumeric characters. The arugments are injected inside the message selector and must be proceeded by a colon (`:`). For example, `between:and:` is a keyword message with a receiver and two arguments. It can be used like this: `13 between: 12 and: 14`.
+A keyword message is a [message](#message) where two or more objects are involved (the [receiver](#receiver) and the arguments). A message is composed of alphanumeric characters. The arguments are injected inside the message selector and must be preceded by a colon (`:`). For example, `between:and:` is a keyword message with a receiver and two arguments. It can be used like this: `13 between: 12 and: 14`.
 
 ## Late binding
-*Late binding* (or *dynamic binding*) is a general mechanism in which methods or function called are [looked up](#lookup) at run-time. This mechanism is opposed to *early binding* that does the lookup at compilation-time and that fixes all types of variables at that time.
-More concretely it means that in Pharo, when you send a [messag](#message) to an object, the lookup of the method to execute is done and then the method found by the lookup is executed. This simplifies the use of reflectivity since the user can invoke new methods without recompiling the whole application.
+*Late binding* (or *dynamic binding*) is a general mechanism in which methods or functions called are [looked up](#lookup) at run-time. This mechanism is the opposite of *early binding* that does the lookup at compilation-time and fixes all types of variables during that time.
+More concretely, it means that in Pharo, when you send a [message](#message) to an object, the lookup of the method to execute is performed and then the method found by the lookup is executed. This simplifies the use of reflectivity since the user can invoke new methods without recompiling the whole application.
 
 ## Lookup
-Method lookup is the name of the technique Pharo uses to find the method to execute when an object receive a [message](#message). It proceeds as follows: When a message is sent, methods in the [receiver](#receiver)'s class are searched for a matching method. If no match is found, the superclass is searched, and so on up the superclass chain. In the end if no method is found, the object call the method [`#doesNotUnderstand:`](#doesnotunderstand) with the message as parameter.
+Method lookup is the name of the technique Pharo uses to find the method to execute when an object receives a [message](#message). It proceeds as follows: When a message is sent, methods in the [receiver](#receiver)'s class are searched for a matching method. If no match is found, the superclass is searched, and so on up the class chain. In the end, if no method is found, the object calls the method [`#doesNotUnderstand:`](#doesnotunderstand) with the message as a parameter.
 
 ## Message
 A message represents an interaction between two objects.
 A [sender](#sender) sends a message to a [receiver](#receiver) which will start a [lookup](#lookup).
-A message is composed of two elements: the selector, which is the name of the method to lookup, and argument values which are the values of each arguments of the method to execute once find by the lookup.
+A message is composed of two elements: the selector, which is the name of the method to lookup, and argument values which are the values of each argument of the method to execute once found by the lookup.
 Three kinds of messages exists: [unary messages](#unary-message), [binary messages](#binary-message) and [keyword messages](#keyword-message).
 
 ## Message-send
 
 ## Monticello
-*Monticello* is a distributed versioning system for [Squeak](#squeak) and Pharo code. It was the main versionning system until Pharo 6. It is now recommanded to use [Iceberg](#iceberg).
+*Monticello* is a distributed versioning system for [Squeak](#squeak) and Pharo code. It was the main versioning system until Pharo 6. It is now recommended to use [Iceberg](#iceberg).
 
 ## Object
 The word object is used to refer to a particular [instance](#instance) of a [class](#class). "Object" and "instance" words are synonyms.
@@ -151,7 +151,7 @@ The word object is used to refer to a particular [instance](#instance) of a [cla
 ## Playground
 The playground / workspace designate a code editor allowing one to run Smalltalk code that is not contained in a method.
 This tool is useful to run small scripts that can be thrown after the execution.
-If one need to write a script that needs to be kept for a long time, it is better to right it as a class-method with the `<script>` pragma.
+If one needs to write a script that needs to be kept for a long time, it is better to right it as a class-method with the `<script>` pragma.
 
 ## Polymorphism
 
@@ -162,16 +162,16 @@ A page dedicated to pragmas is available [here](Pragmas.md).
 ## Primitive
 A primitive is a method for which the source code is not written in Smalltalk but directly in C code. From the inside of the image, those methods contain a `<primitive:>` pragma.
 
-Some methods holding this primitive pragma also contain source code written in Smalltalk. For these methods, first the C version of the method is tried but if the implementation in C is not provided by the VM for some reason, Pharo falls back to the smalltalk implementation.
+Some methods holding this primitive pragma also contain source code written in Smalltalk. For these methods, first the C version of the method is tried but if the implementation in C is not provided by the VM for some reason, Pharo falls back to the Smalltalk implementation.
 
 ## Protocol
-In Pharo, each method belongs to a protocol. A protocol has a name and allows one to group methods that are related together. For example, the protocol `accessing` is widely used in the system to hold accessor and mutator methods.
+In Pharo, each method belongs to a protocol. A protocol has a name and allows one to group methods that are related. For example, the protocol `accessing` is widely used in the system to hold accessor and mutator methods.
 
 ## Receiver
 The receiver of a [message](#message) send is the instance of a class implementing the method corresponding to the message sent receiving this message.
 
 ## Selector
-A selector corresponds to the signature of a method in the system. Since Pharo is not statically typed, the selector of a method is simply a Symbol. On a CompiledMethod, it is possible to send `#selector` message to retrieve this Symbol.
+A selector corresponds to the signature of a method in the system. Since Pharo is not statically typed, the selector of a method is simply a Symbol. On a CompiledMethod, it is possible to send the `#selector` message to retrieve this Symbol.
 
 ## Self
 Self is the [receiver](#receiver) of a [message](#message) an object sends to itself. This means that the [lookup](#lookup) of a method send will start by the sender of this message then, if not found, it will proceed with its superclass.
@@ -183,22 +183,22 @@ The sender of a [message](#message) is the object that will send a message to an
 For a given selector in the system, senders are the methods sending a message with this selector. For example, the senders of the method `#banana` are all the methods sending the message `#banana` in their code.
 
 ## Sista 
-Sista is the name of a [virtual machine](#virtual-machine) with adaptive optimisations such as speculative inlining (it means that the Virtual machine tries to guess the type of receiver and arguments and based on this heavily optimises the code at runtime, in case of wrong guess it deoptimises the code). It showed better performance but is still currently under developement. It is not yet production ready.
+Sista is the name of a [virtual machine](#virtual-machine) with adaptive optimisations such as speculative inlining (meaning that the Virtual machine tries to guess the type of receiver and the arguments. Based on this, it heavily optimises the code at runtime, in case of a wrong guess it de-optimises the code). It showed better performance but is still currently under development. It is not yet production-ready.
 
 ## Slang
 The term "Slang" refers to a subset of the Smalltalk language that can be translated to C (or other language, such as Javascript). It is mainly used to develop the [Cog](#cog) virtual machine. It allows one to develop the virtual machine using Pharo tools and generates C.
 
 ## Slot
-Instance variables are reified in Pharo, which means they are real objects that can be manipulated as any other object.
-Because of that, the name *slot* has been given to the general concept of instance variable in Pharo.
+Instance variables are reified in Pharo, which means they are real objects that can be manipulated just like any other object.
+Because of that, the name *slot* has been given to the general concept of an instance variable in Pharo.
 In practice, most of the slots in classes of the system are `InstanceVariableSlot`.
 One can create a new kind of slot by subclassing `Slot` class (see [this blogpost](https://medium.com/@juliendelplanque/typed-slots-for-pharo-98ba5d5aafbe) as an example).
 
 ## Smalltalk
-Smalltalk is an object-oriented, dynamically typed reflective programming language with multiple implementations. Some implemenations includes [Squeak](#squeak), VisualWorks, Gemstone, VA Smalltalk and many others. Pharo started as an implementation of Smalltalk and is still very close to it.
+Smalltalk is an object-oriented, dynamically typed reflective programming language with multiple implementations. Some implemenations include [Squeak](#squeak), VisualWorks, Gemstone, VA Smalltalk and many others. Pharo started as an implementation of Smalltalk and is still very close to it.
 
 ## Sources (file)
-The sources file contains source code of Pharo. Sources file is important because the image file format stores only objects including compiled methods and their bytecode and not their source code. Originally, a new sources file was generated once per major release of Pharo. Now Pharo changed its production mechanisme to be [bootstraped](#bootstrap) and generates a new sources file for each Pharo image produced.
+The sources file contains source code of Pharo. Sources file is important because the image file format stores only objects including compiled methods and their bytecode and not their source code. Originally, a new sources file was generated once per major release of Pharo. Now, Pharo changed its production mechanism to be [bootstraped](#bootstrap) and generates a new sources file for each Pharo image produced.
 
 ## Spur
 Spur is the name of the current object representation in memory of Pharo used by the [virtual machine](#virtual-machine). This representation is used since Pharo 5 and was introduced to improve performances (by 30% compared to the previous implementation) and prepare Pharo to run in 64bits.
@@ -207,21 +207,20 @@ Spur is the name of the current object representation in memory of Pharo used by
 Squeak is a dialect of [Smalltalk](#smalltalk). Pharo started as a fork of Squeak and both still share the same [virtual machine](#virtual-machine).
 
 ## Super
-Super is the [receiver](#receiver) of a [message](#message) an object send to itself, but on the contrary of [self](#self), the method lookup will start in the superclass of a receiver. Super is a unique way for the class to add behavior
-to the inherited methods and not just replace them.
+Super is the [receiver](#receiver) of a [message](#message) an object send to itself, but on the contrary of [self](#self), the method lookup will start in the superclass of a receiver. Super is a unique way for the class to add behavior to the inherited methods and not just replace them.
 
 ## Traits
 Traits are pure units of behavior that can be composed to form classes or other traits. The trait composition mechanism is an alternative to multiple or mixin inheritance in which the composer has full control over the trait composition. It enables more reuse than single inheritance without introducing the drawbacks of multiple or mixin inheritance.
 A page dedicated to traits is available [here](Traits.md).
 
 ## Unary message
-An unary message is a [message](#message) where only the [receiver](#receiver) of the message will be involved, which is the reason it is call unary. This means that the message will have no argument. For example, `#factorial` is an unary message that will only involve the number receiving the message.
+An unary message is a [message](#message) where only the [receiver](#receiver) of the message will be required, which is the reason it is called unary. This means that the message will have no argument. For example, `#factorial` is an unary message that will only require the number receiving the message.
 
 ## VM
 See [virtual machine](#virtual-machine).
 
 ## Virtual Machine
-The virtual machine of Pharo is the execution engine. It takes Pharo bytcode that is generated each time user compiles a piece of code, converts it to machine code and executes it. The VM is different for each platform running Pharo (windows, OSX, linux, arm, 32/64bits) and allows the other part of pharo to be platform independant.
+The virtual machine of Pharo is the execution engine. It takes Pharo bytecode that is generated each time the user compiles a piece of code, converts it to machine code and executes it. The VM is different for each platform running Pharo (windows, OSX, linux, arm, 32/64bits) and allows the other part of Pharo to be platform independent.
 
 ## Workspace
 Workspace is the previous name of the [Playground](#playground).

--- a/General/HowToRunPharoFromCommandLine.md
+++ b/General/HowToRunPharoFromCommandLine.md
@@ -1,7 +1,7 @@
 # Getting Pharo runnning from the command line
 
-Here are some simple steps to get pharo ready from the command line. The script 
-presupposes that you have a bin folder in your home directory. 
+Here are some simple steps to get Pharo ready from the command line. The script 
+assumes that you have a bin folder in your home directory. 
 
 The following script downloads the stable vm version of Pharo 80. Check the web page [https://get.pharo.org/64/](https://get.pharo.org/64/)
 to get the possible choices. 
@@ -20,7 +20,7 @@ Once installed you can execute pharo as follows:
 ./pharo-ui Pharo8.image 
 ```
 
-If you do not want that pharo pops-up a user interface you can invoke it as follows: 
+If you do not want Pharo displaying a user interface as a pop-up, you can invoke it as follows: 
 
 ```bash
 ./pharo Pharo8.image 

--- a/General/InterestingsToKnowForBeginners.md
+++ b/General/InterestingsToKnowForBeginners.md
@@ -23,9 +23,9 @@ The Pharo API is extensive. In this section we will explain various methods exis
 String concatenation can be costly because it will create a new string instance and copy the content of the two strings at each concatenation. To make it more efficient, Pharo includes a method to create a String via a stream:
 
 ```Smalltalk
-'This is a ', 'strong concatenation ' , 'that is not really' , ' ' , ' efficient'.
+'This is a ', 'string concatenation ' , 'that is not really' , ' ' , ' efficient'.
 
-String streamContents: [ :aStream | aStream << 'This is a '<< 'strong concatenation ' << 'that is ' << ' ' << ' efficient' ]
+String streamContents: [ :aStream | aStream << 'This is a '<< 'string concatenation ' << 'that is ' << ' ' << ' efficient' ]
 ```
 
 ## Evaluatable objects (Blocks and Symbols)
@@ -43,7 +43,7 @@ For example, the two code snippets below are equivalent:
 
 They both return the class of an object.
 
-This means that for methods taking a one-argument block as a parameter, this block can be replaced by a symbol. The effect is that the unary method named by the symbol will be executed with the object as receiver.
+This means that for methods taking a one-argument block as a parameter, this block can be replaced by a symbol. The effect is that the unary method named by the symbol will be executed with the object as the receiver.
 
 The difference between `#value:` and `#cull:` is that `#value:` requires a parameter when `#cull:` can work with or without a parameter.
 
@@ -89,7 +89,7 @@ Commonly used flags are:
 - `#toCheck` to mark code that should be checked later.
 - `#pharoX` to mark code present for compatibility with `X` being the version of Pharo.
 
-Flags will not modify the execution of a method. It is just a way to tag it.
+Flags will not modify the execution of a method. Flags are just used to tag methods.
 
 For example, the method below will return `42` if executed as if there was no call to `#flag:` method.
 
@@ -110,16 +110,16 @@ Pragmas allow one to tag methods. They are similar to Java's annotations. Some p
 - `<script>` for class-side methods, adds a button next to the method name in the IDE. This button, when clicked, executes the method.
 - `<script: 'Smalltalk code to run'>` is similar to `<script>` but the button executes the Smalltalk code held by the string provided as parameter to the pragma.
 - `<sampleInstance>` for class-side methods, adds a button next to the method name in the IDE. When clicked, the method is executed and an inspector is opened on its result.
-- `<worldMenu>` for class-side methods, add a menu entry in the Pharo menu. The method with this pragma should take a builder as parameter. You can browse the senders of the `worldMenu` pragma to find the API.
-- `<systemsettings>` for class-side methods, add an entry in the Pharo settings. The method with this pragma should take a builder as parameter. You can browse the senders of the `systemsettings` pragma to find the API.
+- `<worldMenu>` for class-side methods, add a menu entry in the Pharo menu. The method with this pragma should take a builder as a parameter. You can browse the senders of the `worldMenu` pragma to find the API.
+- `<systemsettings>` for class-side methods, add an entry in the Pharo settings. The method with this pragma should take a builder as a parameter. You can browse the senders of the `systemsettings` pragma to find the API.
 - `<haltOrBreakpointForTesting>` should be used in methods using breakpoints that should not be listed in the Breakpoint browser. For example, it can be used in examples using breakpoints to highlight a feature of the example.
 
 ### Influence execution of methods
 
-- `<expectedFailure>` for instance-side methods of subclasses of `TestCase`, will make the test green when it is failing. But, althrough we expect that the test fails, a success of the test (i.e. not assertion missed) will show as a failure.
+- `<expectedFailure>` for instance-side methods of subclasses of `TestCase`, will make the test green when it is failing. But, although we expect that the test will fail, a success of the test (i.e. not assertion missed) will show as a failure.
 
 ### Influence Debugger
-- `<debuggerCompleteToSender>` allows one to tell the debugger to open itself on the method that sends the message corresponging to the method holding `<debuggerCompleteToSender>` pragma.
+- `<debuggerCompleteToSender>` allows one to tell the debugger to open itself on the method that sends the message corresponding to the method holding the `<debuggerCompleteToSender>` pragma.
 
 For example, let us consider these two methods:
 ```st

--- a/General/MustKnowForBeginners.md
+++ b/General/MustKnowForBeginners.md
@@ -16,9 +16,9 @@ Pharo offers a lot of ways to navigate into the code, and most of those are used
 ### Browse, Senders and Implementors
 
 When reading code we often need to open an entity or to check who is using an entity. To do that, Pharo has different commands:
-* **Browse** (`CMD/CTRL + b`): This command will open a new system browser on the class you are currently focusing
-* **Senders/References** (`CMD/CTRL + n`): This command will open a message browser with all the methods calling the method/symbol you are currently focusing, or, in the case where you are focusing a class, the references to this class. 
-* **Implementors** (`CMD/CTRL + m`):  This command will open a message browser with all the methods whose name is the name of the method/symbol you are currently focusing, or, in the case where you are focusing a class, the references to this class like `browse`. 
+* **Browse** (`CMD/CTRL + b`): This command will open a new system browser on the class you are currently focusing on
+* **Senders/References** (`CMD/CTRL + n`): This command will open a message browser with all the methods calling the method/symbol you are currently focusing on, or, in the case where you are focusing on a class, the references to this class. 
+* **Implementors** (`CMD/CTRL + m`):  This command will open a message browser with all the methods whose name is the name of the method/symbol you are currently focusing on, or, in the case where you are focusing on a class, the references to this class like `browse`. 
 
 Alternatively, it is possible to navigate the code using the mouse and the keyboard. In most text editors of Pharo you can use the shortcut `CMD + (Shift +) click` on OSX or `Alt + (Shift +) right click` on Windows/Linux to browse senders, implementors, classes and references. 
 
@@ -32,11 +32,11 @@ Using `CMD + (Shift +) click` on OSX or `Alt + (Shift +) right click` on Windows
 - Browse the references to a class when you click on a class.
 - Browse the references to a class or senders of a method represented by a symbol when you click on a symbol. 
 
-> Warning: The click shortcuts on symbols are only working starting from Pharo 9. In previous version, it will browse the ByteSymbol class. 
+> Warning: The click shortcuts on symbols are only working starting from Pharo 9. In the previous version, it will browse the ByteSymbol class. 
 
 ### Method source with it
 
-It often happens that we want to see how a feature is done, or we want to edit something but we do not know *where* is the implementation. If we have the name of a menu for example we can use it to find every places in the image were the name of the menu is written. 
+It often happens that we want to see how a feature is done, or we want to edit something but we do not know *where* the implementation is. If we have the name of a menu, for example we can use it to find every location in the image where the name of the menu is written. 
 
 To do that we need to open a playground and type the text (or select some text in an editor) then select on a right click `Code search...` then `Method source with it`.
 
@@ -44,22 +44,22 @@ This will open a message browser with all the methods/class comments containing 
 
 ## Interrupt the Pharo process
 
-Pharo currently run in one native thread. If you launch a method taking a lot of time to run, or if you have an infinite loop in your code, you might want to interrupt the process. 
+Pharo currently runs in one native thread. If you launch a method taking a lot of time to run, or if you have an infinite loop in your code, you might want to interrupt the process. 
 
 It is possible to do that in Pharo with the shortcut `CMD/ALT + .`.
 
-> This feature will work in most cases. However, sometimes it might not work, e.g. when a faulty code will have fill up too much memory, or when a process is executing outside of the VM (FFI calls).
+> This feature will work in most cases. However, sometimes it might not work, e.g. when faulty code would have taken up too much memory, or when a process is executing outside of the VM (FFI calls).
 
 ## Debugging facilities
 
 Pharo includes multiple ways to help with debugging. This section gives some of them.
 
-`Object` implements multiple debugging messages that are useful. They can be sent to any objects in your code:
+`Object` implements multiple debugging messages that are useful. They can be sent to any object in your code:
 
-- `#halt` : This method will stop the execution of your code when it is called and open a debugger. (/!\ Do not use it in a code called multiple times in a fork, or system critical loops or you cqn regret it by breaking your image. In this case, it is advise to not save your image in this kind of unstable state)
-- `#haltOnce` : This method stops the execution and raise a debugger only the first time it is called. To enable it once more, use `Menubar -> Debbuging -> Enable all break/inspect once`.
-- `#haltIf:` : This method takes a block as parameter and will stop the execution and open a debugger if the block as parameter returns `true`.
-- `#haltOnCount:` : This method takes a number as argument and will stop the execution and open a debugger when it will be called at least the number of time given as argument. Reset the counter via `Menubar -> Debbuging -> Reset Counters`.
+- `#halt` : This method will stop the execution of your code when it is called and will open a debugger. (/!\ Do not use it in a code called multiple times in a fork, or system critical loops or you can regret it by breaking your image. In this case, it is advisable to not save your image in this kind of unstable state)
+- `#haltOnce` : This method stops the execution and raises a debugger only on the first time it is called. To enable it once more, use `Menubar -> Debbuging -> Enable all break/inspect once`.
+- `#haltIf:` : This method takes a block as a parameter. It will stop the execution and open the debugger if the block as parameter returns `true`.
+- `#haltOnCount:` : This method takes a number as an argument, it will stop the execution and open the debugger when it will be called at least the number of times given as argument. Reset the counter via `Menubar -> Debbuging -> Reset Counters`.
 - `#inspect` : This message can be called on any object and will open an inspector for the receiver.
 - `#inspectOnce` : This message works like #haltOnce for inspecting.
 


### PR DESCRIPTION
I have corrected various spelling mistakes and minor grammar mistakes for the Beginner section of the documentation.

Please note, that the below description regarding the Receiver in the Glossary section, is very confusing for a beginner and I recommend the explanation be simplified. I read the sentence a couple of times but still didn't understand it in order to propose a correction.

_"**Receiver**
The receiver of a message send is the instance of a class implementing the method corresponding to the message sent receiving this message._"