### PR TITLE
add other remote git project

### DIFF
--- a/General/Baselines.md
+++ b/General/Baselines.md
@@ -164,11 +164,11 @@ This snippet should be configured with:
   - `bitbucket` for bitbucket
   - `gitlab` for gitlab
   - `git` for others (and {url} is thus mandatory)
-- `{url}`: base url to the git host. Mandatory when prefix `git` is used.
+- `{url}`: Base url to the git host. Mandatory when prefix `git` is used, not needed for other prefixes
 - `{owner}`: Name of the user or organization hosting the project
 - `{projectName}`: Name of the project
 - `{version}`: This parameter is optional (defaults to master). It can be the name of a branch, a tag like `'v1.2.0'` or `'v1.x.x'`, or a the SHA of a commit
-- `{subfolder}`: This parameter is optional in case the code is not at the root of the project. It should point to the sub-folder containing the code.
+- `{subfolder}`: This parameter is optional in case the code is not at the root of the project. It should point to the sub-folder containing the code
 
 Example:
 

--- a/General/Baselines.md
+++ b/General/Baselines.md
@@ -153,7 +153,7 @@ To depend on a git project, you can use the method `#baseline:with:`.
 ```Smalltalk
 spec
 	baseline: '{BaselineName}'
-	with: [ spec repository: '{prefix}://{owner}/{projectName}:{version}/{subfolder}' ]
+	with: [ spec repository: '{prefix}://{url}:{owner}/{projectName}:{version}/{subfolder}' ]
 ```
 
 This snippet should be configured with:
@@ -163,6 +163,8 @@ This snippet should be configured with:
   - `github` for github
   - `bitbucket` for bitbucket
   - `gitlab` for gitlab
+  - `git` for others (and {url} is thus mandatory)
+- `{url}`: base url to the git host. Mandatory when prefix `git` is used.
 - `{owner}`: Name of the user or organization hosting the project
 - `{projectName}`: Name of the project
 - `{version}`: This parameter is optional (defaults to master). It can be the name of a branch, a tag like `'v1.2.0'` or `'v1.x.x'`, or a the SHA of a commit


### PR DESCRIPTION
For how to deal with baseline 

I added the documentation for when the remote dependency is hosted on something else than gitlab/github/bitbucket.

i discovered that thanks to https://discord.com/channels/223421264751099906/299884664795955200/1162638383760293959