### PR TITLE
Added text in Strep 2, for change in syntax for Pharo 13 or later vesrion 

### DIFF
--- a/General/SettingUpANewProject.md
+++ b/General/SettingUpANewProject.md
@@ -25,6 +25,7 @@ Open the list of `Official distributions` in the left panel and double-click on 
 
 ## Step 2. Create a package and a class
 
+!! ( In Pharo 13 or more latest version, we have "**slots: { #variable }**" instead of "**instanceVariableNames: 'variable'**" )
 
 Let us make our first package. In your newly made image in Pharo Launcher, in the top menu bar choose *Tools* then *System Browser*.
 


### PR DESCRIPTION
Added text as "instanceVariableNames: is no longer used in Pharo 13. Instead, Pharo now uses slots for defining instance variables".